### PR TITLE
Add Bivariate Bicycle Code

### DIFF
--- a/src/TensorQEC.jl
+++ b/src/TensorQEC.jl
@@ -37,7 +37,7 @@ export PauliString, PauliGroup, isanticommute,paulistring
 export syndrome_inference, measure_syndrome!,correction_pauli_string, generate_syndrome_dict,pauli_string_map_iter, inference, transformed_syndrome_dict
 
 # codes 
-export toric_code, stabilizers,ToricCode, SurfaceCode, ShorCode,SteaneCode,Code832, Code422, Code1573, Code513
+export toric_code, stabilizers,ToricCode, SurfaceCode, ShorCode,SteaneCode,Code832, Code422, Code1573, Code513, BivariateBicycleCode
 
 # encoder
 export CSSBimatrix,syndrome_transform, encode_stabilizers,place_qubits
@@ -76,7 +76,7 @@ export decode,reduce2general,extract_decoding,general_syndrome,DecodingResult,CS
 export multi_round_qec
 
 # code distance
-export code_distance
+export code_distance,logical_qubit_number
 
 # error_learning
 export TrainningData,error_learning

--- a/src/TensorQEC.jl
+++ b/src/TensorQEC.jl
@@ -37,7 +37,7 @@ export PauliString, PauliGroup, isanticommute,paulistring
 export syndrome_inference, measure_syndrome!,correction_pauli_string, generate_syndrome_dict,pauli_string_map_iter, inference, transformed_syndrome_dict
 
 # codes 
-export toric_code, stabilizers,ToricCode, SurfaceCode, ShorCode,SteaneCode,Code832, Code422, Code1573, Code513, BivariateBicycleCode
+export stabilizers,ToricCode, SurfaceCode, ShorCode,SteaneCode,Code832, Code422, Code1573, Code513, BivariateBicycleCode
 
 # encoder
 export CSSBimatrix,syndrome_transform, encode_stabilizers,place_qubits

--- a/src/codes/code_distance.jl
+++ b/src/codes/code_distance.jl
@@ -101,3 +101,9 @@ function code_distance(tanner::CSSTannerGraph)
     dz = code_distance(Int.(tanner.stgx.H), Int.(lx))
     return min(dx,dz)
 end
+
+function remove_linear_dependency(sts::Vector{PauliString{N}}) where N
+	code = stabilizers2bimatrix(sts)
+	code2 = gaussian_elimination!(code)
+    return sts[any.(!iszero, eachrow(code2.matrix))]
+end

--- a/test/codes/codes.jl
+++ b/test/codes/codes.jl
@@ -146,3 +146,15 @@ end
 @testset "Code513" begin
 	st = stabilizers(Code513())
 end
+
+@testset "[[98,6,12]] BivariateBicycleCode" begin
+	st = stabilizers(BivariateBicycleCode(7,7, ((1,0),(0,3),(0,4)), ((0,1),(3,0),(4,0))))
+	@test length(st) == 92
+	# @test code_distance(CSSTannerGraph(st)) == 12
+end
+
+@testset "[[144,12,12]] BivariateBicycleCode" begin
+	st = stabilizers(BivariateBicycleCode(6,12, ((3,0),(0,1),(0,2)), ((0,3),(1,0),(2,0))))
+	@test length(st) == 132
+	# @test code_distance(CSSTannerGraph(st)) == 12
+end

--- a/test/codes/ldpc.jl
+++ b/test/codes/ldpc.jl
@@ -50,7 +50,7 @@ end
     
     pgraph = product_graph(tanner1, tanner2)
 
-    st_toric = stabilizers(ToricCode(3,3);linearly_independent = false)
+    st_toric = stabilizers(ToricCode(3,3);rm_linear_dependency = false)
     tanner_toric = CSSTannerGraph(st_toric)
 
     g1 = get_graph(pgraph)


### PR DESCRIPTION
Bivariate Bicycle Code from [High-threshold and low-overhead fault-tolerant quantum memory](https://www.nature.com/articles/s41586-024-07107-7)