### PR TITLE
Add 4.8.8 and 6.6.6 triangular color code

### DIFF
--- a/src/TensorQEC.jl
+++ b/src/TensorQEC.jl
@@ -37,7 +37,7 @@ export PauliString, PauliGroup, isanticommute,paulistring
 export syndrome_inference, measure_syndrome!,correction_pauli_string, generate_syndrome_dict,pauli_string_map_iter, inference, transformed_syndrome_dict
 
 # codes 
-export stabilizers,ToricCode, SurfaceCode, ShorCode,SteaneCode,Code832, Code422, Code1573, Code513, BivariateBicycleCode
+export stabilizers,ToricCode, SurfaceCode, ShorCode,SteaneCode,Code832, Code422, Code1573, Code513, BivariateBicycleCode,Color488,Color666
 
 # encoder
 export CSSBimatrix,syndrome_transform, encode_stabilizers,place_qubits

--- a/test/codes/codes.jl
+++ b/test/codes/codes.jl
@@ -158,3 +158,17 @@ end
 	@test length(st) == 132
 	# @test code_distance(CSSTannerGraph(st)) == 12
 end
+
+@testset "Color488" begin
+	d = 5
+	st = stabilizers(Color488(d))
+	@test length(st) == 16
+	@test code_distance(CSSTannerGraph(st)) == d
+end
+
+@testset "Color666" begin
+	d = 5
+	st = stabilizers(Color666(d))
+	@test length(st) == 18
+	@test code_distance(CSSTannerGraph(st)) == d
+end


### PR DESCRIPTION
Main references: 
1. [Fault-tolerant quantum computing with color codes](https://arxiv.org/abs/1108.5738)
2. This [PR](https://github.com/QuantumSavory/QuantumClifford.jl/pull/361) to QuantumClifford.jl