### PR TITLE
Add Aqua test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ TensorInference = "c2297e78-99bd-40ad-871d-f50e56b81012"
 Yao = "5872b779-8223-5990-8dd0-5abbb0748c8c"
 
 [compat]
+Aqua = "0.8"
 BitBasis = "0.9.10"
 Combinatorics = "1"
 DelimitedFiles = "1"
@@ -42,9 +43,10 @@ Yao = "0.9"
 julia = "1"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Documenter", "Random", "Test"]
+test = ["Aqua", "Documenter", "Random", "Test"]

--- a/src/TensorQEC.jl
+++ b/src/TensorQEC.jl
@@ -36,7 +36,6 @@ export PauliString, PauliGroupElement, isanticommute
 
 # clifford group
 export CliffordGate, clifford_simulate, compile_clifford_circuit
-export plot_error_propagation
 
 # tensor network
 export clifford_network, CliffordNetwork, generate_tensor_network, circuit2tensornetworks
@@ -51,7 +50,7 @@ export stabilizers, ToricCode, SurfaceCode, ShorCode, SteaneCode, Code832, Code4
 export CSSBimatrix, syndrome_transform, encode_stabilizers, place_qubits
 
 # measurement
-export measure_circuit_fault_tol, measure_circuit_steane, measure_circuit, measure_circuit_steane_single_type
+export measure_circuit_fault_tol, measure_circuit_steane, measure_circuit
 
 # tablemake
 export make_table, save_table, load_table, correction_circuit, TruthTable, correction_dict
@@ -61,8 +60,8 @@ export ComplexConj, SymbolRecorder, IdentityRecorder, ein_circ, QCInfo, qc2enisu
 export coherent_error_unitary, error_quantum_circuit, toput, error_pairs, fidelity_tensornetwork, simulation_tensornetwork, error_quantum_circuit_pair_replace
 
 # ldpc
-export SimpleTannerGraph, syndrome_extraction, product_graph, CSSTannerGraph, plot_graph, dual_graph, get_graph, belief_propagation, random_ldpc, check_linear_indepent
-export tensor_infer, osd, mod2matrix_inverse, bp_osd, tensor_osd, check_logical_error
+export SimpleTannerGraph, syndrome_extraction, product_graph, CSSTannerGraph, dual_graph, get_graph, belief_propagation, random_ldpc, check_linear_indepent
+export osd, mod2matrix_inverse, check_logical_error
 
 # tableaux
 export Tableau, new_tableau, tableau_simulate
@@ -72,10 +71,10 @@ export IndependentFlipError, IndependentDepolarizingError, random_error_qubits, 
 @const_gate CCZ::ComplexF64 = diagm([1, 1, 1, 1, 1, 1, 1, -1])
 
 # decoder
-export BPOSD, BPDecoder, IPDecoder, MatchingDecoder, IPMatchingSolver, TNMAP, TableDecoder
+export BPDecoder, IPDecoder, MatchingDecoder, IPMatchingSolver, TNMAP, TableDecoder
 
 # decoding
-export decode, reduce2general, extract_decoding, general_syndrome, DecodingResult, compile, IndependentDepolarizingDecodingProblem, ClassicalDecodingProblem, GeneralDecodingProblem
+export decode, reduce2general, extract_decoding, DecodingResult, compile, IndependentDepolarizingDecodingProblem, ClassicalDecodingProblem, GeneralDecodingProblem
 
 # threshold
 export multi_round_qec
@@ -85,9 +84,6 @@ export code_distance, logical_operator
 
 # error_learning
 export TrainningData, error_learning
-
-# multiprocessing
-export multiprocess_run
 
 include("codes/mod2.jl")
 include("clifford/paulistring.jl")

--- a/src/codes/gaussian_elimination.jl
+++ b/src/codes/gaussian_elimination.jl
@@ -101,14 +101,11 @@ function gaussian_elimination!(bimat::CSSBimatrix)
 	return bimat
 end
 
-function Base.inv(H::Transpose{Bool, Matrix{Bool}})
-    bm = SimpleBimatrix(Transpose(copy(H.parent)), Transpose(Matrix{Mod2}(I, size(H,1), size(H,1))), collect(1:size(H,2)))
+function Base.inv(H::Matrix{Mod2})
+    H = Transpose([a.x for a in Transpose(H)])
+    bm = SimpleBimatrix(H, Transpose(Matrix{Mod2}(I, size(H,1), size(H,1))), collect(1:size(H,2)))
     gaussian_elimination!(bm, 1:size(bm.matrix,1), 0, 0;allow_col_operation = false)
     return bm.Q
-end
-
-function Base.inv(H::Matrix{Mod2})
-    return inv(Transpose([a.x for a in Transpose(H)]))
 end
 
 function _check_linear_indepent(H::Transpose{Bool, Matrix{Bool}})

--- a/src/codes/mod2.jl
+++ b/src/codes/mod2.jl
@@ -19,6 +19,8 @@ julia> Mod2(true) + Mod2(true)
 """
 struct Mod2 <: Number
     x::Bool
+    Mod2(x::Bool) = new(x)
+    Mod2(x::Int) = new(Bool(x))
 end
 
 # display

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -1,8 +1,6 @@
 @deprecate PauliGroup PauliGroupElement
 @deprecate densitymatrix2sumofpaulis(dm) pauli_decomposition(dm)
 @deprecate arrayreg2sumofpaulis(t) pauli_decomposition(t)
-@deprecate PauliString(t::NTuple{N, Int} where N) PauliString(Pauli.(t .- 1))
-@deprecate PauliString(t::Int, ts::Int...) PauliString((Pauli(t-1), Pauli.(ts .- 1)...))
 @deprecate paulistring(nq::Int, idx, pos) PauliString(nq, pos => Pauli(idx-1))
 import Yao: apply!
 @deprecate apply!(reg::ArrayReg, ps::PauliString) apply!(reg, yaoblock(ps))

--- a/src/nonclifford/error_learning.jl
+++ b/src/nonclifford/error_learning.jl
@@ -12,7 +12,7 @@ function probability_tn(qc::ChainBlock, final_state::Vector{Complex{Float64}})
     return optnet
 end
 
-function Yao.depolarizing_channel(n::Int, p_vec::AbstractVector)
+function n_qubit_depolarizing_channel(n::Int, p_vec::AbstractVector)
     return UnitaryChannel(vec(yaoblock.(pauli_basis(n))),p_vec)
 end
 

--- a/src/nonclifford/simulation.jl
+++ b/src/nonclifford/simulation.jl
@@ -4,19 +4,19 @@ end
 ComplexConj(x::BT) where {D,BT<:AbstractBlock{D}} = ComplexConj{BT,D}(x)
 Yao.mat(::Type{T}, blk::ComplexConj) where {T} = conj(mat(T, content(blk)))
 
-Base.conj(x::Union{XGate, ZGate,HGate}) = x
-Base.conj(x::AbstractBlock) = ComplexConj(x)
-Base.conj(x::ComplexConj) = content(x)
+conjugate(x::Union{XGate, ZGate,HGate}) = x
+conjugate(x::AbstractBlock) = ComplexConj(x)
+conjugate(x::ComplexConj) = content(x)
 Base.copy(x::ComplexConj) = ComplexConj(copy(content(x)))
 YaoBlocks.chsubblocks(blk::ComplexConj, target::AbstractBlock) = ComplexConj(target)
 
-Base.conj(blk::ChainBlock{D}) where {D} =
-    ChainBlock(blk.n, AbstractBlock{D}[conj(b) for b in subblocks(blk)])
-Base.conj(x::PutBlock) = PutBlock(nqudits(x), conj(content(x)), x.locs)
+conjugate(blk::ChainBlock{D}) where {D} =
+    ChainBlock(blk.n, AbstractBlock{D}[conjugate(b) for b in subblocks(blk)])
+    conjugate(x::PutBlock) = PutBlock(nqudits(x), conjugate(content(x)), x.locs)
 
-Base.conj(blk::ControlBlock) =
-    ControlBlock(blk.n, blk.ctrl_locs, blk.ctrl_config, conj(blk.content), blk.locs)
-Base.conj(blk::GeneralMatrixBlock)= matblock(conj(blk.mat))
+conjugate(blk::ControlBlock) =
+    ControlBlock(blk.n, blk.ctrl_locs, blk.ctrl_config, conjugate(blk.content), blk.locs)
+conjugate(blk::GeneralMatrixBlock)= matblock(conj(blk.mat))
 function YaoBlocks.map_address(blk::ComplexConj, info::AddressInfo)
     ComplexConj(YaoBlocks.map_address(content(blk), info))
 end
@@ -98,7 +98,7 @@ function dm_circ!(qcf::ChainBlock, qc::ChainBlock)
     num_qubits = nqubits(qc)
     @assert 2 * num_qubits == nqubits(qcf)
     push!(qcf,subroutine(2*num_qubits, qc, 1:num_qubits))
-    push!(qcf,subroutine(2*num_qubits, conj(qc), num_qubits+1:2*num_qubits))
+    push!(qcf,subroutine(2*num_qubits, conjugate(qc), num_qubits+1:2*num_qubits))
     return qcf
 end
 

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,0 +1,2 @@
+using Aqua
+Aqua.test_all(TensorQEC)

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,2 +1,3 @@
 using Aqua
+using TensorQEC
 Aqua.test_all(TensorQEC)

--- a/test/deprecate.jl
+++ b/test/deprecate.jl
@@ -1,10 +1,9 @@
-using TensorQEC, Test, Yao
+using TensorQEC, Test, Yao, BitBasis
 
 @testset "deprecate" begin
     @test PauliGroup(P"XX") isa PauliGroupElement
     @test densitymatrix2sumofpaulis(rand_density_matrix(2)) isa SumOfPaulis
     @test arrayreg2sumofpaulis(rand_state(2)) isa SumOfPaulis
-    @test PauliString(1, 2, 3) == PauliString((Pauli(0), Pauli(1), Pauli(2)))
     @test paulistring(2, 1, 2) == PauliString(2, 2 => Pauli(0))
     @test apply!(ArrayReg(bit"00"), PauliString(2, 2 => Pauli(0))) == ArrayReg(bit"00")
     gate = rand_unitary(4)

--- a/test/nonclifford/error_learning.jl
+++ b/test/nonclifford/error_learning.jl
@@ -1,6 +1,6 @@
 using Test
 using TensorQEC
-using TensorQEC: qc_probability, TrainingChannel, probability_tn_channel, channel2mat, channel2tensor, probability_channel, get_grad,generate_new_tensor,loss_function
+using TensorQEC: qc_probability, TrainingChannel, probability_tn_channel, channel2mat, channel2tensor, probability_channel, get_grad,generate_new_tensor,loss_function, n_qubit_depolarizing_channel
 using TensorQEC.Yao
 using TensorQEC.OMEinsum
 using Random
@@ -32,7 +32,7 @@ end
 end
 
 @testset "probability_tn_channel" begin
-    unitary_channel = depolarizing_channel(2, fill(1 / 16, 16))
+    unitary_channel = n_qubit_depolarizing_channel(2, fill(1 / 16, 16))
     qc = chain(put(2, (1, 2) => unitary_channel))
 
     reg = rand_state(2)
@@ -41,7 +41,7 @@ end
 
 @testset "generate_new_tensor" begin
     p2 = 0.02
-    unitary_channel2 = depolarizing_channel(2, [1 - 15 * p2, fill(p2, 15)...])
+    unitary_channel2 = n_qubit_depolarizing_channel(2, [1 - 15 * p2, fill(p2, 15)...])
 
     Random.seed!(1234)
     umat = rand_unitary(4)
@@ -51,14 +51,14 @@ end
     p3 = 0.01
     new_t = generate_new_tensor(optnet.tensors,p_pos,ComplexF64[0, 1, 0, 0],[[1 - 15 * p3, fill(p3, 15)...]])
 
-    unitary_channel2 = depolarizing_channel(2, [1 - 15 * p3, fill(p3, 15)...])
+    unitary_channel2 = n_qubit_depolarizing_channel(2, [1 - 15 * p3, fill(p3, 15)...])
     qc = chain(put(2, (1, 2) => matblock(umat)), put(2, (1, 2) => unitary_channel2))
     @test probability_channel(qc, ComplexF64[0, 1, 0, 0]) ≈  optnet.code(new_t...)[]
 end 
 
 @testset "error_learning" begin
     p2 = fill(0.02,15)
-    unitary_channel2 = depolarizing_channel(2, [1 - sum(p2), p2...])
+    unitary_channel2 = n_qubit_depolarizing_channel(2, [1 - sum(p2), p2...])
 
     Random.seed!(1234)
     umat = rand_unitary(4)
@@ -81,7 +81,7 @@ end
 
 @testset "error_learning" begin
     p2 = fill(0.1,3)
-    unitary_channel1 = depolarizing_channel(1, [1 - sum(p2), p2...])
+    unitary_channel1 = n_qubit_depolarizing_channel(1, [1 - sum(p2), p2...])
 
     Random.seed!(1234)
     umat = rand_unitary(4)
@@ -104,7 +104,7 @@ end
 
 @testset "get_grad" begin
     p2 = 0.02
-    unitary_channel2 = depolarizing_channel(2, [1 - 15 * p2, fill(p2, 15)...])
+    unitary_channel2 = n_qubit_depolarizing_channel(2, [1 - 15 * p2, fill(p2, 15)...])
 
     Random.seed!(1234)
     umat = rand_unitary(4)

--- a/test/nonclifford/simulation.jl
+++ b/test/nonclifford/simulation.jl
@@ -10,7 +10,7 @@ using TensorQEC.Yao.YaoBlocks.Optimise
     ccj = ComplexConj(ConstGate.X)
     @test ccj isa ComplexConj
     @test apply!(product_state(bit"1"), ccj) ≈ apply!(product_state(bit"1"), ConstGate.X)
-    @test conj(ccj) == ConstGate.X
+    @test TensorQEC.conjugate(ccj) == ConstGate.X
     @test copy(ccj) == ccj
 
     qc = chain(2, put(2, 1 => X), put(2, 2 => ccj))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,10 @@ using TensorQEC
 using Test
 using Documenter
 
+@testset "aqua" begin
+    include("aqua.jl")
+end
+
 @testset "mod2" begin
     include("codes/mod2.jl")
 end


### PR DESCRIPTION
The following aqua tests fail:
1. Undefined exports (fixed)
2. Ambiguities(fixed)
3. [Type piracy](https://juliatesting.github.io/Aqua.jl/stable/piracies/#Type-piracy)(unfixed). `conj` of YaoBlocks is not allowed.
```Julia
Possible type-piracy detected:
[1] conj(blk::YaoBlocks.ControlBlock) @ TensorQEC ~/jcode/TensorQEC.jl/src/nonclifford/simulation.jl:17
[2] conj(blk::YaoBlocks.GeneralMatrixBlock) @ TensorQEC ~/jcode/TensorQEC.jl/src/nonclifford/simulation.jl:19
[3] conj(x::YaoAPI.AbstractBlock) @ TensorQEC ~/jcode/TensorQEC.jl/src/nonclifford/simulation.jl:8
[4] conj(x::YaoBlocks.PutBlock) @ TensorQEC ~/jcode/TensorQEC.jl/src/nonclifford/simulation.jl:15
[5] conj(blk::YaoBlocks.ChainBlock{D}) where D @ TensorQEC ~/jcode/TensorQEC.jl/src/nonclifford/simulation.jl:13
[6] conj(x::Union{YaoBlocks.ConstGate.HGate, YaoBlocks.ConstGate.XGate, YaoBlocks.ConstGate.ZGate}) @ TensorQEC ~/jcode/TensorQEC.jl/src/nonclifford/simulation.jl:7
[7] depolarizing_channel(n::Int64, p_vec::AbstractVector) @ TensorQEC ~/jcode/TensorQEC.jl/src/nonclifford/error_learning.jl:15
Piracy: Test Failed at /Users/nizhongyi/.julia/dev/Aqua/src/piracies.jl:229
  Expression: isempty(v)
   Evaluated: isempty(Method[conj(blk::YaoBlocks.ControlBlock) @ TensorQEC ~/jcode/TensorQEC.jl/src/nonclifford/simulation.jl:17, conj(blk::YaoBlocks.GeneralMatrixBlock) @ TensorQEC ~/jcode/TensorQEC.jl/src/nonclifford/simulation.jl:19, conj(x::YaoAPI.AbstractBlock) @ TensorQEC ~/jcode/TensorQEC.jl/src/nonclifford/simulation.jl:8, conj(x::YaoBlocks.PutBlock) @ TensorQEC ~/jcode/TensorQEC.jl/src/nonclifford/simulation.jl:15, conj(blk::YaoBlocks.ChainBlock{D}) where D @ TensorQEC ~/jcode/TensorQEC.jl/src/nonclifford/simulation.jl:13, conj(x::Union{YaoBlocks.ConstGate.HGate, YaoBlocks.ConstGate.XGate, YaoBlocks.ConstGate.ZGate}) @ TensorQEC ~/jcode/TensorQEC.jl/src/nonclifford/simulation.jl:7, depolarizing_channel(n::Int64, p_vec::AbstractVector) @ TensorQEC ~/jcode/TensorQEC.jl/src/nonclifford/error_learning.jl:15])

Stacktrace:
 [1] macro expansion
   @ ~/.julia/juliaup/julia-1.11.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/Test/src/Test.jl:679 [inlined]
 [2] test_piracies(m::Module; broken::Bool, kwargs::@Kwargs{})
   @ Aqua ~/.julia/dev/Aqua/src/piracies.jl:229
 [3] test_piracies
   @ ~/.julia/dev/Aqua/src/piracies.jl:206 [inlined]
 [4] macro expansion
   @ ~/.julia/dev/Aqua/src/Aqua.jl:96 [inlined]
 [5] macro expansion
   @ ~/.julia/juliaup/julia-1.11.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/Test/src/Test.jl:1704 [inlined]
 [6] test_all(testtarget::Module; ambiguities::Bool, unbound_args::Bool, undefined_exports::Bool, project_extras::Bool, stale_deps::Bool, deps_compat::Bool, piracies::Bool, persistent_tasks::Bool, undocumented_names::Bool)
   @ Aqua ~/.julia/dev/Aqua/src/Aqua.jl:96
Test Summary: | Fail  Total  Time
Piracy        |    1      1  1.0s
ERROR: Some tests did not pass: 0 passed, 1 failed, 0 errored, 0 broken.
```