### PR TITLE
Add logical action verification for CSS codes

### DIFF
--- a/docs/superpowers/specs/2026-06-04-logical-action-verification-design.md
+++ b/docs/superpowers/specs/2026-06-04-logical-action-verification-design.md
@@ -1,0 +1,133 @@
+# Logical Action Verification Design
+
+Date: 2026-06-04
+
+## Goal
+
+Add a small verification utility for CSS codes that checks whether a physical Pauli operator preserves the stabilizer group and how it commutes with the code's logical X/Z operators.
+
+This utility is meant for code-level diagnostics and tests. The first target test is the Steane code logical X operator.
+
+## Scope
+
+In scope:
+
+- Verify stabilizer preservation for a physical Pauli operator.
+- Report commutation against each provided logical X operator.
+- Report commutation against each provided logical Z operator.
+- Support general CSS codes with `k >= 1` logical qubits.
+
+Out of scope:
+
+- Identifying a final logical label such as logical `I/X/Y/Z`.
+- Verifying non-Pauli Clifford gates.
+- Building the verification around state simulation or encoding-circuit simulation.
+
+## Chosen Approach
+
+Use pure Pauli algebra on existing `PauliString` values.
+
+For a Pauli operator `op`, stabilizer preservation is checked by testing commutation with every stabilizer generator in `stabilizers`. Logical action is diagnosed by testing commutation with every row-derived logical operator from `lx` and `lz`.
+
+This approach matches the existing codebase:
+
+- `PauliString` already represents physical Pauli operators.
+- `iscommute` / `isanticommute` already implement Pauli commutation checks.
+- `logical_operator(tanner)` already produces logical X/Z operators as `Mod2` matrices.
+
+No new simulation layer is needed.
+
+## API
+
+Add:
+
+```julia
+verify_logical_action(
+    stabilizers::AbstractVector{PauliString{N}},
+    lx::AbstractMatrix{Mod2},
+    lz::AbstractMatrix{Mod2},
+    op::PauliString{N},
+) where N
+```
+
+The function will return a small result object:
+
+```julia
+struct LogicalActionVerification
+    preserves_stabilizers::Bool
+    commutes_with_stabilizers::Vector{Bool}
+    commutes_with_lx::Vector{Bool}
+    commutes_with_lz::Vector{Bool}
+end
+```
+
+This keeps the interface explicit and easy to assert against in tests.
+
+## Data Conversion
+
+`lx` and `lz` are provided as binary matrices over `Mod2`, one row per logical operator.
+
+Each logical row will be converted to a `PauliString` using existing repository conventions:
+
+- a row from `lx` becomes an X-type `PauliString`
+- a row from `lz` becomes a Z-type `PauliString`
+- active qubit positions are extracted with `findall(i -> i.x, row)`
+
+This matches existing patterns already used elsewhere in the repository.
+
+## Semantics
+
+### Stabilizer Preservation
+
+For the current scope, `op` is always a Pauli operator. A Pauli operator preserves the stabilizer group iff it commutes with every stabilizer generator supplied in `stabilizers`.
+
+The function will therefore compute:
+
+- `commutes_with_stabilizers[i] = iscommute(op, stabilizers[i])`
+- `preserves_stabilizers = all(commutes_with_stabilizers)`
+
+### Logical Commutation Diagnostics
+
+For each logical operator row:
+
+- `commutes_with_lx[j] = iscommute(op, logical_x_j)`
+- `commutes_with_lz[j] = iscommute(op, logical_z_j)`
+
+For `k = 1`, this reduces to one Bool for logical X and one Bool for logical Z.
+
+For `k > 1`, the result reports one Bool per logical qubit, preserving the row order already established by `logical_operator`.
+
+## Validation and Error Handling
+
+The function should defensively assert:
+
+- `size(lx, 1) == size(lz, 1)` so both logical bases describe the same number of logical qubits.
+- every stabilizer and `op` act on the same number of qubits.
+- `size(lx, 2)` and `size(lz, 2)` match that qubit count.
+
+No attempt will be made to re-derive or validate that the supplied `lx` and `lz` are a correct logical basis; the function trusts the caller on that point.
+
+## Testing
+
+Add a focused testset using `SteaneCode()`:
+
+1. Build `st = stabilizers(SteaneCode())`.
+2. Build `tanner = CSSTannerGraph(st)`.
+3. Compute `lx, lz = logical_operator(tanner)`.
+4. Convert `lx[1, :]` into a physical X-type `PauliString`.
+5. Run `verify_logical_action(st, lx, lz, op)`.
+
+Expected assertions:
+
+- `result.preserves_stabilizers == true`
+- `all(result.commutes_with_stabilizers)`
+- `result.commutes_with_lx == [true]`
+- `result.commutes_with_lz == [false]`
+
+This verifies that the chosen physical operator behaves as Steane logical X: it preserves the code space, commutes with logical X, and anticommutes with logical Z.
+
+## File Placement
+
+Implementation should stay close to the existing logical-operator utilities. The preferred placement is alongside code-distance and logical-operator helpers, with exports added from `src/TensorQEC.jl`.
+
+Tests should live with the existing logical-operator tests under `test/codes/code_distance.jl`, unless a cleaner nearby file becomes obvious during implementation.

--- a/src/TensorQEC.jl
+++ b/src/TensorQEC.jl
@@ -82,7 +82,7 @@ export decode, reduce2general, extract_decoding, DecodingResult, compile, Indepe
 export multi_round_qec
 
 # code distance
-export code_distance, logical_operator
+export code_distance, logical_operator, verify_logical_action, LogicalActionVerification
 
 # error_learning
 export TrainningData, error_learning

--- a/src/codes/code_distance.jl
+++ b/src/codes/code_distance.jl
@@ -99,6 +99,42 @@ function same_qubit_order(lx::Matrix{Mod2},lz::Matrix{Mod2})
     return lx_new, lz
 end
 
+struct LogicalActionVerification
+    preserves_stabilizers::Bool
+    commutes_with_stabilizers::Vector{Bool}
+    commutes_with_lx::Vector{Bool}
+    commutes_with_lz::Vector{Bool}
+end
+
+function _logical_row_to_paulistring(row::AbstractVector{Mod2}, pauli::Pauli)
+    nq = length(row)
+    positions = findall(x -> x.x, row)
+    return PauliString(nq, positions => pauli)
+end
+
+function verify_logical_action(
+    stabilizers::AbstractVector{PauliString{N}},
+    lx::AbstractMatrix{Mod2},
+    lz::AbstractMatrix{Mod2},
+    op::PauliString{N},
+) where N
+    @assert size(lx, 1) == size(lz, 1) "The logical X/Z bases must have the same number of rows"
+    @assert size(lx, 2) == N "The logical X operators must act on the same number of qubits as op"
+    @assert size(lz, 2) == N "The logical Z operators must act on the same number of qubits as op"
+    @assert all(length(st) == N for st in stabilizers) "All stabilizers must act on the same number of qubits as op"
+
+    commutes_with_stabilizers = [iscommute(op, st) for st in stabilizers]
+    commutes_with_lx = [iscommute(op, _logical_row_to_paulistring(lx[i, :], Pauli(1))) for i in axes(lx, 1)]
+    commutes_with_lz = [iscommute(op, _logical_row_to_paulistring(lz[i, :], Pauli(3))) for i in axes(lz, 1)]
+
+    return LogicalActionVerification(
+        all(commutes_with_stabilizers),
+        commutes_with_stabilizers,
+        commutes_with_lx,
+        commutes_with_lz,
+    )
+end
+
 function code_distance(Hz::Matrix{Int},lz::Matrix{Int}; verbose = false,ipsolver = SCIP.Optimizer)
     m,n = size(Hz)
     num_lz = size(lz, 1)

--- a/test/codes/code_distance.jl
+++ b/test/codes/code_distance.jl
@@ -1,6 +1,6 @@
 using Test
 using TensorQEC
-using TensorQEC: row_echelon_form,null_space,logical_operator, same_qubit_order
+using TensorQEC: row_echelon_form, null_space, logical_operator, same_qubit_order, verify_logical_action
 using Random
 
 @testset "classical_code_distance" begin
@@ -55,6 +55,20 @@ end
     lx,lz = logical_operator(tannerxz)
     @test lx == Mod2[0 0 0 0 0 0 1 1 1]
     @test lz == Mod2[1 0 0 0 1 0 0 0 1]
+end
+
+@testset "verify_logical_action" begin
+    st = stabilizers(SteaneCode())
+    tanner = CSSTannerGraph(st)
+    lx, lz = logical_operator(tanner)
+    op = PauliString(7, findall(i -> i.x, lx[1, :]) => Pauli(1))
+
+    result = verify_logical_action(st, lx, lz, op)
+
+    @test result.preserves_stabilizers
+    @test all(result.commutes_with_stabilizers)
+    @test result.commutes_with_lx == [true]
+    @test result.commutes_with_lz == [false]
 end
 
 @testset "code_distance" begin

--- a/test/codes/code_distance.jl
+++ b/test/codes/code_distance.jl
@@ -82,6 +82,36 @@ end
     @test_throws AssertionError verify_logical_action(st, lx, bad_lz, op)
 end
 
+@testset "verify_logical_action detects broken stabilizers" begin
+    st = stabilizers(SteaneCode())
+    tanner = CSSTannerGraph(st)
+    lx, lz = logical_operator(tanner)
+    op = PauliString(7, 1 => Pauli(1))
+
+    result = verify_logical_action(st, lx, lz, op)
+
+    @test !result.preserves_stabilizers
+    @test any(.!result.commutes_with_stabilizers)
+end
+
+@testset "verify_logical_action supports multiple logical qubits" begin
+    st = stabilizers(ToricCode(3, 3))
+    tanner = CSSTannerGraph(ToricCode(3, 3))
+    lx, lz = logical_operator(tanner)
+
+    op1 = PauliString(size(lx, 2), findall(i -> i.x, lx[1, :]) => Pauli(1))
+    result1 = verify_logical_action(st, lx, lz, op1)
+    @test result1.preserves_stabilizers
+    @test result1.commutes_with_lx == [true, true]
+    @test result1.commutes_with_lz == [false, true]
+
+    op2 = PauliString(size(lx, 2), findall(i -> i.x, lx[2, :]) => Pauli(1))
+    result2 = verify_logical_action(st, lx, lz, op2)
+    @test result2.preserves_stabilizers
+    @test result2.commutes_with_lx == [true, true]
+    @test result2.commutes_with_lz == [true, false]
+end
+
 @testset "code_distance" begin
     tannerxz = CSSTannerGraph(SurfaceCode(3, 3))
     lx,lz = logical_operator(tannerxz)

--- a/test/codes/code_distance.jl
+++ b/test/codes/code_distance.jl
@@ -71,6 +71,17 @@ end
     @test result.commutes_with_lz == [false]
 end
 
+@testset "verify_logical_action validation" begin
+    st = stabilizers(SteaneCode())
+    tanner = CSSTannerGraph(st)
+    lx, lz = logical_operator(tanner)
+    op = PauliString(7, 1 => Pauli(1))
+
+    bad_lz = zeros(Mod2, size(lz, 1), size(lz, 2) - 1)
+
+    @test_throws AssertionError verify_logical_action(st, lx, bad_lz, op)
+end
+
 @testset "code_distance" begin
     tannerxz = CSSTannerGraph(SurfaceCode(3, 3))
     lx,lz = logical_operator(tannerxz)


### PR DESCRIPTION
## Summary
- add verify_logical_action and LogicalActionVerification for CSS-code Pauli logical-action checks
- add Steane happy-path, validation, broken-stabilizer, and multi-logical-qubit coverage in test/codes/code_distance.jl
- include the design spec for this feature under docs/superpowers/specs/

## Test Plan
- julia --project=. --color=yes test/codes/code_distance.jl
- julia --project=. --color=yes test/runtests.jl
