### PR TITLE
Add logical Clifford action analysis for stabilizer codes

### DIFF
--- a/docs/superpowers/specs/2026-06-05-logical-clifford-action-design.md
+++ b/docs/superpowers/specs/2026-06-05-logical-clifford-action-design.md
@@ -1,0 +1,255 @@
+# Logical Clifford Action Design
+
+Date: 2026-06-05
+
+## Goal
+
+Add a reusable verification framework that computes how a physical Clifford action induces a logical Clifford action on a stabilizer code.
+
+The immediate acceptance target is the transversal CNOT between two `ToricCode(3,3)` blocks, verified entirely at the Pauli/matrix level.
+
+## Scope
+
+In scope:
+
+- Reducing a physical Pauli operator to logical Pauli coordinates modulo stabilizers.
+- Computing the logical action induced by an arbitrary physical Clifford action on the logical Pauli generators.
+- Verifying that the physical Clifford preserves the code space.
+- Supporting stabilizer codes described by `stabilizers`, `lx`, and `lz`.
+- Using the double-`ToricCode(3,3)` transversal CNOT as the primary end-to-end test.
+
+Out of scope for the first version:
+
+- Automatically naming the induced logical Clifford as `CNOT`, `H`, `S`, etc.
+- Synthesizing a logical circuit from the induced action.
+- Handling non-Clifford physical operations.
+- Building a fully general symplectic linear algebra framework beyond the needs of this API.
+
+## Design Summary
+
+The implementation is split into two layers:
+
+1. A logical-coordinate reducer for physical Pauli operators.
+2. A logical-Clifford analyzer that applies a user-supplied physical Clifford action to logical generators and reduces the resulting Pauli images.
+
+This separation keeps the reusable algebraic primitive small and makes the Clifford layer a thin orchestration step.
+
+## Existing Building Blocks
+
+The repository already provides the core ingredients needed for this design:
+
+- `PauliString` and `PauliGroupElement` for physical Pauli operators.
+- `iscommute` / `isanticommute` for Pauli commutation checks.
+- `logical_operator(tanner)` to derive logical X/Z bases.
+- `same_qubit_order` to align the logical X/Z bases.
+- `CliffordGate` application on `PauliString` / `PauliGroupElement` for Clifford conjugation.
+
+No state simulation, encoder simulation, or new circuit abstraction is required.
+
+## API
+
+### Logical Pauli Reduction
+
+Add:
+
+```julia
+logical_pauli_coordinates(
+    stabilizers::AbstractVector{PauliString{N}},
+    lx::AbstractMatrix{Mod2},
+    lz::AbstractMatrix{Mod2},
+    op::PauliString{N},
+) where N
+```
+
+Return:
+
+```julia
+struct LogicalPauliCoordinates
+    preserves_stabilizers::Bool
+    x_bits::Vector{Bool}
+    z_bits::Vector{Bool}
+end
+```
+
+Semantics:
+
+- If `preserves_stabilizers == true`, then `op` is logically equivalent to
+  `prod_j X_j^(x_bits[j]) Z_j^(z_bits[j])`,
+  up to multiplication by stabilizers and an overall phase.
+- If `preserves_stabilizers == false`, the bit vectors are still diagnostic but should not be treated as a valid logical Pauli representative.
+
+### Logical Clifford Analysis
+
+Add:
+
+```julia
+logical_clifford_action(
+    stabilizers::AbstractVector{PauliString{N}},
+    lx::AbstractMatrix{Mod2},
+    lz::AbstractMatrix{Mod2},
+    act_on_pauli::Function,
+) where N
+```
+
+Where `act_on_pauli(op)` returns the conjugated Pauli `U op U†` as a `PauliGroupElement`.
+
+Return:
+
+```julia
+struct LogicalCliffordAction
+    preserves_code::Bool
+    stabilizer_images::Vector{LogicalPauliCoordinates}
+    x_images::Vector{LogicalPauliCoordinates}
+    z_images::Vector{LogicalPauliCoordinates}
+end
+```
+
+Semantics:
+
+- `stabilizer_images[i]` is the reduced image of the `i`th stabilizer generator.
+- `x_images[j]` is the reduced image of logical `X_j`.
+- `z_images[j]` is the reduced image of logical `Z_j`.
+- `preserves_code == true` means the supplied physical Clifford preserves the encoded subspace and induces a well-defined logical Clifford action on the provided logical basis.
+
+## Data Representation
+
+`lx` and `lz` are binary `Mod2` matrices with one row per logical qubit. Each row is converted into a physical `PauliString` using the same conventions already used in `verify_logical_action`:
+
+- a row from `lx` becomes an X-type `PauliString`
+- a row from `lz` becomes a Z-type `PauliString`
+
+For `k` logical qubits, the logical Pauli coordinates are represented by two length-`k` Boolean vectors:
+
+- `x_bits[j] == true` means the logical image contains `X_j`
+- `z_bits[j] == true` means the logical image contains `Z_j`
+
+This representation naturally supports:
+
+- pure X-type or Z-type logical operators
+- mixed logical Paulis containing both X and Z support
+- logical Clifford actions that interchange X and Z structure
+
+## Logical Pauli Reduction Semantics
+
+For a physical Pauli operator `op`, reduction proceeds as follows:
+
+1. Check commutation with every stabilizer generator.
+2. If any stabilizer anticommutes with `op`, set `preserves_stabilizers = false`.
+3. Compute logical coordinates by commutation against the logical basis:
+   - `x_bits[j] = isanticommute(op, logical_z_j)`
+   - `z_bits[j] = isanticommute(op, logical_x_j)`
+
+This works because the provided `lx`/`lz` basis is already paired by `same_qubit_order`, so each pair forms a canonical logical symplectic basis.
+
+The reducer does not need to explicitly solve for the stabilizer multiplier. The commutation signature already identifies the logical Pauli class modulo stabilizers.
+
+## Code-Preservation Semantics
+
+For a physical Clifford action `U`, `preserves_code` should be `true` exactly when all of the following hold:
+
+1. For every stabilizer generator `s`, the image `U s U†` preserves stabilizers.
+2. For every stabilizer generator image, the reduced logical coordinates are trivial:
+   - all `x_bits` are `false`
+   - all `z_bits` are `false`
+3. For every logical generator image `U X_j U†` and `U Z_j U†`, the image preserves stabilizers.
+
+This is stricter than merely asking stabilizer images to commute with the stabilizer group. A stabilizer image with nontrivial logical coordinates would not preserve the code space pointwise and must therefore be rejected.
+
+## Physical Clifford Interface
+
+The first version should accept the physical action as a function:
+
+```julia
+act_on_pauli(op::PauliString{N}) -> PauliGroupElement{N}
+```
+
+This keeps the API compatible with existing repository patterns:
+
+- a transversal CNOT can be implemented by repeatedly applying `CliffordGate(ConstGate.CNOT)`
+- a compiled Clifford circuit can later be wrapped behind the same callable shape
+
+The analyzer should treat phase as irrelevant for logical-coordinate extraction, while preserving the `PauliGroupElement` return type to stay faithful to the underlying Clifford action.
+
+## Validation and Error Handling
+
+The new APIs should assert:
+
+- `size(lx, 1) == size(lz, 1)`
+- `size(lx, 2) == size(lz, 2) == N`
+- every stabilizer has length `N`
+
+The APIs trust the caller that:
+
+- the supplied stabilizers define a valid stabilizer code
+- the supplied `lx` and `lz` define a valid paired logical basis for that code
+
+The APIs should not attempt to reconstruct or repair an invalid logical basis.
+
+## File Placement
+
+Implementation should live next to the existing logical-operator utilities:
+
+- add the new result types and functions in `src/codes/code_distance.jl`
+- export them from `src/TensorQEC.jl`
+
+Tests should live in:
+
+- `test/codes/code_distance.jl`
+
+This keeps logical-operator diagnostics and logical-action verification in one place.
+
+## Testing
+
+### 1. Logical Pauli Reduction
+
+Add focused tests that confirm known logical operators reduce to the expected coordinates:
+
+- `SteaneCode()` single-logical-qubit checks
+- `ToricCode(3,3)` multi-logical-qubit checks
+
+Expected behavior:
+
+- a physical representative of logical `X_j` yields `x_bits[j] == true` and all other logical bits `false`
+- a physical representative of logical `Z_j` yields `z_bits[j] == true` and all other logical bits `false`
+- a non-logical Pauli that breaks stabilizers sets `preserves_stabilizers == false`
+
+### 2. Logical Clifford Framework
+
+Add a small test where the physical action is known and easy to reason about, using a callable `act_on_pauli` and checking that `logical_clifford_action` returns the expected logical-generator images.
+
+The test should verify both:
+
+- the returned logical coordinates
+- the `preserves_code` decision
+
+### 3. Acceptance Test: Double Toric Transversal CNOT
+
+Construct two `ToricCode(3,3)` blocks as an 18-qubit system:
+
+1. Build one block's stabilizers and logical basis.
+2. Embed one copy as control qubits `1:9` and one copy as target qubits `10:18`.
+3. Form the combined stabilizer set and combined logical basis.
+4. Define `act_on_pauli` by composing the 9 physical pairwise CNOT conjugations.
+
+The expected logical action is two independent logical CNOTs, one per logical pair:
+
+- `Xc_1 -> Xc_1 Xt_1`
+- `Xc_2 -> Xc_2 Xt_2`
+- `Xt_1 -> Xt_1`
+- `Xt_2 -> Xt_2`
+- `Zc_1 -> Zc_1`
+- `Zc_2 -> Zc_2`
+- `Zt_1 -> Zc_1 Zt_1`
+- `Zt_2 -> Zc_2 Zt_2`
+
+This test is the first required proof that the framework can answer the user's original verification question without building a state-level circuit simulation.
+
+## Non-Goals
+
+The first implementation should avoid:
+
+- introducing a new global abstraction for arbitrary symplectic maps
+- inferring named logical gates from the returned Pauli-generator images
+- expanding into non-CSS-specific convenience helpers unless needed by the tests
+
+The goal is a compact, defensible algebraic API with one real acceptance case.

--- a/src/TensorQEC.jl
+++ b/src/TensorQEC.jl
@@ -84,6 +84,7 @@ export multi_round_qec
 # code distance
 export code_distance, logical_operator, verify_logical_action, LogicalActionVerification
 export logical_pauli_coordinates, LogicalPauliCoordinates
+export logical_clifford_action, LogicalCliffordAction
 
 # error_learning
 export TrainningData, error_learning

--- a/src/TensorQEC.jl
+++ b/src/TensorQEC.jl
@@ -83,6 +83,7 @@ export multi_round_qec
 
 # code distance
 export code_distance, logical_operator, verify_logical_action, LogicalActionVerification
+export logical_pauli_coordinates, LogicalPauliCoordinates
 
 # error_learning
 export TrainningData, error_learning

--- a/src/codes/code_distance.jl
+++ b/src/codes/code_distance.jl
@@ -163,6 +163,37 @@ function _is_trivial_logical_coordinates(coords::LogicalPauliCoordinates)
     return !any(coords.x_bits) && !any(coords.z_bits)
 end
 
+function _logical_coordinates_commute(
+    lhs::LogicalPauliCoordinates,
+    rhs::LogicalPauliCoordinates,
+)
+    anticommutes = false
+    for i in eachindex(lhs.x_bits)
+        anticommutes ⊻= lhs.x_bits[i] && rhs.z_bits[i]
+        anticommutes ⊻= lhs.z_bits[i] && rhs.x_bits[i]
+    end
+    return !anticommutes
+end
+
+function _preserves_logical_symplectic_form(
+    x_images::AbstractVector{LogicalPauliCoordinates},
+    z_images::AbstractVector{LogicalPauliCoordinates},
+)
+    for i in eachindex(x_images)
+        for j in eachindex(x_images)
+            _logical_coordinates_commute(x_images[i], x_images[j]) || return false
+            _logical_coordinates_commute(z_images[i], z_images[j]) || return false
+            commute = _logical_coordinates_commute(x_images[i], z_images[j])
+            if i == j
+                commute && return false
+            else
+                !commute && return false
+            end
+        end
+    end
+    return true
+end
+
 function logical_clifford_action(
     stabilizers::AbstractVector{PauliString{N}},
     lx::AbstractMatrix{Mod2},
@@ -171,10 +202,11 @@ function logical_clifford_action(
 ) where N
     _validate_logical_action_inputs(stabilizers, lx, lz, N)
     x_generators, z_generators = _logical_generators(lx, lz)
+    stabilizer_group_images = [act_on_pauli(st) for st in stabilizers]
 
     stabilizer_images = [
-        logical_pauli_coordinates(stabilizers, lx, lz, act_on_pauli(st).ps)
-        for st in stabilizers
+        logical_pauli_coordinates(stabilizers, lx, lz, image.ps)
+        for image in stabilizer_group_images
     ]
     x_images = [
         logical_pauli_coordinates(stabilizers, lx, lz, act_on_pauli(xgen).ps)
@@ -185,15 +217,15 @@ function logical_clifford_action(
         for zgen in z_generators
     ]
 
-    preserves_stabilizer_images = all(
-        coords -> coords.preserves_stabilizers && _is_trivial_logical_coordinates(coords),
-        stabilizer_images,
-    )
+    preserves_stabilizer_images = all(zip(stabilizer_group_images, stabilizer_images)) do (image, coords)
+        image.phase == 0 && coords.preserves_stabilizers && _is_trivial_logical_coordinates(coords)
+    end
     preserves_logical_images = all(coords -> coords.preserves_stabilizers, x_images) &&
         all(coords -> coords.preserves_stabilizers, z_images)
+    preserves_logical_structure = _preserves_logical_symplectic_form(x_images, z_images)
 
     return LogicalCliffordAction(
-        preserves_stabilizer_images && preserves_logical_images,
+        preserves_stabilizer_images && preserves_logical_images && preserves_logical_structure,
         stabilizer_images,
         x_images,
         z_images,

--- a/src/codes/code_distance.jl
+++ b/src/codes/code_distance.jl
@@ -112,6 +112,13 @@ struct LogicalPauliCoordinates
     z_bits::Vector{Bool}
 end
 
+struct LogicalCliffordAction
+    preserves_code::Bool
+    stabilizer_images::Vector{LogicalPauliCoordinates}
+    x_images::Vector{LogicalPauliCoordinates}
+    z_images::Vector{LogicalPauliCoordinates}
+end
+
 function _logical_row_to_paulistring(row::AbstractVector{Mod2}, pauli::Pauli)
     nq = length(row)
     positions = findall(x -> x.x, row)
@@ -150,6 +157,47 @@ function logical_pauli_coordinates(
     z_bits = [isanticommute(op, xgen) for xgen in x_generators]
 
     return LogicalPauliCoordinates(preserves_stabilizers, x_bits, z_bits)
+end
+
+function _is_trivial_logical_coordinates(coords::LogicalPauliCoordinates)
+    return !any(coords.x_bits) && !any(coords.z_bits)
+end
+
+function logical_clifford_action(
+    stabilizers::AbstractVector{PauliString{N}},
+    lx::AbstractMatrix{Mod2},
+    lz::AbstractMatrix{Mod2},
+    act_on_pauli::Function,
+) where N
+    _validate_logical_action_inputs(stabilizers, lx, lz, N)
+    x_generators, z_generators = _logical_generators(lx, lz)
+
+    stabilizer_images = [
+        logical_pauli_coordinates(stabilizers, lx, lz, act_on_pauli(st).ps)
+        for st in stabilizers
+    ]
+    x_images = [
+        logical_pauli_coordinates(stabilizers, lx, lz, act_on_pauli(xgen).ps)
+        for xgen in x_generators
+    ]
+    z_images = [
+        logical_pauli_coordinates(stabilizers, lx, lz, act_on_pauli(zgen).ps)
+        for zgen in z_generators
+    ]
+
+    preserves_stabilizer_images = all(
+        coords -> coords.preserves_stabilizers && _is_trivial_logical_coordinates(coords),
+        stabilizer_images,
+    )
+    preserves_logical_images = all(coords -> coords.preserves_stabilizers, x_images) &&
+        all(coords -> coords.preserves_stabilizers, z_images)
+
+    return LogicalCliffordAction(
+        preserves_stabilizer_images && preserves_logical_images,
+        stabilizer_images,
+        x_images,
+        z_images,
+    )
 end
 
 function verify_logical_action(

--- a/src/codes/code_distance.jl
+++ b/src/codes/code_distance.jl
@@ -106,10 +106,50 @@ struct LogicalActionVerification
     commutes_with_lz::Vector{Bool}
 end
 
+struct LogicalPauliCoordinates
+    preserves_stabilizers::Bool
+    x_bits::Vector{Bool}
+    z_bits::Vector{Bool}
+end
+
 function _logical_row_to_paulistring(row::AbstractVector{Mod2}, pauli::Pauli)
     nq = length(row)
     positions = findall(x -> x.x, row)
     return PauliString(nq, positions => pauli)
+end
+
+function _validate_logical_action_inputs(
+    stabilizers::AbstractVector{PauliString{N}},
+    lx::AbstractMatrix{Mod2},
+    lz::AbstractMatrix{Mod2},
+    nqubits::Int,
+) where N
+    @assert size(lx, 1) == size(lz, 1) "The logical X/Z bases must have the same number of rows"
+    @assert size(lx, 2) == nqubits "The logical X operators must act on the same number of qubits as the input operator"
+    @assert size(lz, 2) == nqubits "The logical Z operators must act on the same number of qubits as the input operator"
+    @assert all(length(st) == nqubits for st in stabilizers) "All stabilizers must act on the same number of qubits as the input operator"
+end
+
+function _logical_generators(lx::AbstractMatrix{Mod2}, lz::AbstractMatrix{Mod2})
+    x_generators = [_logical_row_to_paulistring(lx[i, :], Pauli(1)) for i in axes(lx, 1)]
+    z_generators = [_logical_row_to_paulistring(lz[i, :], Pauli(3)) for i in axes(lz, 1)]
+    return x_generators, z_generators
+end
+
+function logical_pauli_coordinates(
+    stabilizers::AbstractVector{PauliString{N}},
+    lx::AbstractMatrix{Mod2},
+    lz::AbstractMatrix{Mod2},
+    op::PauliString{N},
+) where N
+    _validate_logical_action_inputs(stabilizers, lx, lz, N)
+    x_generators, z_generators = _logical_generators(lx, lz)
+
+    preserves_stabilizers = all(st -> iscommute(op, st), stabilizers)
+    x_bits = [isanticommute(op, zgen) for zgen in z_generators]
+    z_bits = [isanticommute(op, xgen) for xgen in x_generators]
+
+    return LogicalPauliCoordinates(preserves_stabilizers, x_bits, z_bits)
 end
 
 function verify_logical_action(
@@ -118,14 +158,12 @@ function verify_logical_action(
     lz::AbstractMatrix{Mod2},
     op::PauliString{N},
 ) where N
-    @assert size(lx, 1) == size(lz, 1) "The logical X/Z bases must have the same number of rows"
-    @assert size(lx, 2) == N "The logical X operators must act on the same number of qubits as op"
-    @assert size(lz, 2) == N "The logical Z operators must act on the same number of qubits as op"
-    @assert all(length(st) == N for st in stabilizers) "All stabilizers must act on the same number of qubits as op"
+    _validate_logical_action_inputs(stabilizers, lx, lz, N)
+    x_generators, z_generators = _logical_generators(lx, lz)
 
     commutes_with_stabilizers = [iscommute(op, st) for st in stabilizers]
-    commutes_with_lx = [iscommute(op, _logical_row_to_paulistring(lx[i, :], Pauli(1))) for i in axes(lx, 1)]
-    commutes_with_lz = [iscommute(op, _logical_row_to_paulistring(lz[i, :], Pauli(3))) for i in axes(lz, 1)]
+    commutes_with_lx = [iscommute(op, xgen) for xgen in x_generators]
+    commutes_with_lz = [iscommute(op, zgen) for zgen in z_generators]
 
     return LogicalActionVerification(
         all(commutes_with_stabilizers),

--- a/test/codes/code_distance.jl
+++ b/test/codes/code_distance.jl
@@ -230,6 +230,36 @@ end
     @test result.stabilizer_images[1].z_bits == [false]
 end
 
+@testset "logical_clifford_action rejects phased stabilizer images" begin
+    st = stabilizers(SteaneCode())
+    tanner = CSSTannerGraph(st)
+    lx, lz = logical_operator(tanner)
+    phased_action(op) = op == st[1] ? PauliGroupElement(2, st[1]) : PauliGroupElement(op)
+
+    result = logical_clifford_action(st, lx, lz, phased_action)
+
+    @test !result.preserves_code
+    @test result.stabilizer_images[1].preserves_stabilizers
+    @test !any(result.stabilizer_images[1].x_bits)
+    @test !any(result.stabilizer_images[1].z_bits)
+end
+
+@testset "logical_clifford_action rejects degenerate logical images" begin
+    st = stabilizers(SteaneCode())
+    tanner = CSSTannerGraph(st)
+    lx, lz = logical_operator(tanner)
+    logical_x = PauliString(7, findall(i -> i.x, lx[1, :]) => Pauli(1))
+    id7 = PauliString(ntuple(_ -> Pauli(0), Val(7)))
+    degenerate_action(op) = op == logical_x ? PauliGroupElement(id7) : PauliGroupElement(op)
+
+    result = logical_clifford_action(st, lx, lz, degenerate_action)
+
+    @test !result.preserves_code
+    @test result.x_images[1].preserves_stabilizers
+    @test !any(result.x_images[1].x_bits)
+    @test !any(result.x_images[1].z_bits)
+end
+
 @testset "logical_clifford_action detects toric transversal cnot" begin
     st = stabilizers(ToricCode(3, 3))
     tanner = CSSTannerGraph(st)

--- a/test/codes/code_distance.jl
+++ b/test/codes/code_distance.jl
@@ -130,6 +130,48 @@ end
     @test zcoords.z_bits == [true]
 end
 
+@testset "logical_pauli_coordinates is invariant on stabilizer cosets" begin
+    st = stabilizers(SteaneCode())
+    tanner = CSSTannerGraph(st)
+    lx, lz = logical_operator(tanner)
+    op = PauliString(7, findall(i -> i.x, lx[1, :]) => Pauli(1))
+    shifted = (op * st[1]).ps
+
+    coords = logical_pauli_coordinates(st, lx, lz, op)
+    shifted_coords = logical_pauli_coordinates(st, lx, lz, shifted)
+
+    @test coords.preserves_stabilizers
+    @test shifted_coords.preserves_stabilizers
+    @test shifted_coords.x_bits == coords.x_bits
+    @test shifted_coords.z_bits == coords.z_bits
+end
+
+@testset "logical_pauli_coordinates supports mixed logical operators" begin
+    st = stabilizers(SteaneCode())
+    tanner = CSSTannerGraph(st)
+    lx, lz = logical_operator(tanner)
+    opx = PauliString(7, findall(i -> i.x, lx[1, :]) => Pauli(1))
+    opz = PauliString(7, findall(i -> i.x, lz[1, :]) => Pauli(3))
+    opy = (opx * opz).ps
+
+    coords = logical_pauli_coordinates(st, lx, lz, opy)
+
+    @test coords.preserves_stabilizers
+    @test coords.x_bits == [true]
+    @test coords.z_bits == [true]
+end
+
+@testset "logical_pauli_coordinates validation" begin
+    st = stabilizers(SteaneCode())
+    tanner = CSSTannerGraph(st)
+    lx, lz = logical_operator(tanner)
+    op = PauliString(7, 1 => Pauli(1))
+
+    bad_lz = zeros(Mod2, size(lz, 1), size(lz, 2) - 1)
+
+    @test_throws AssertionError logical_pauli_coordinates(st, lx, bad_lz, op)
+end
+
 @testset "logical_pauli_coordinates supports multiple logical qubits" begin
     st = stabilizers(ToricCode(3, 3))
     tanner = CSSTannerGraph(st)

--- a/test/codes/code_distance.jl
+++ b/test/codes/code_distance.jl
@@ -1,6 +1,7 @@
 using Test
 using TensorQEC
 using TensorQEC: row_echelon_form, null_space, logical_operator, same_qubit_order, verify_logical_action, logical_pauli_coordinates
+using TensorQEC.Yao
 using Random
 
 @testset "classical_code_distance" begin
@@ -196,6 +197,80 @@ end
     @test !coords.preserves_stabilizers
     @test coords.x_bits isa Vector{Bool}
     @test coords.z_bits isa Vector{Bool}
+end
+
+@testset "logical_clifford_action identity" begin
+    st = stabilizers(SteaneCode())
+    tanner = CSSTannerGraph(st)
+    lx, lz = logical_operator(tanner)
+    identity_action(op) = PauliGroupElement(op)
+
+    result = logical_clifford_action(st, lx, lz, identity_action)
+
+    @test result.preserves_code
+    @test all(coords -> coords.preserves_stabilizers && !any(coords.x_bits) && !any(coords.z_bits), result.stabilizer_images)
+    @test result.x_images[1].x_bits == [true]
+    @test result.x_images[1].z_bits == [false]
+    @test result.z_images[1].x_bits == [false]
+    @test result.z_images[1].z_bits == [true]
+end
+
+@testset "logical_clifford_action rejects stabilizer images with logical support" begin
+    st = stabilizers(SteaneCode())
+    tanner = CSSTannerGraph(st)
+    lx, lz = logical_operator(tanner)
+    logical_x = PauliString(7, findall(i -> i.x, lx[1, :]) => Pauli(1))
+    bad_action(op) = op == st[1] ? PauliGroupElement(logical_x) : PauliGroupElement(op)
+
+    result = logical_clifford_action(st, lx, lz, bad_action)
+
+    @test !result.preserves_code
+    @test result.stabilizer_images[1].preserves_stabilizers
+    @test result.stabilizer_images[1].x_bits == [true]
+    @test result.stabilizer_images[1].z_bits == [false]
+end
+
+@testset "logical_clifford_action detects toric transversal cnot" begin
+    st = stabilizers(ToricCode(3, 3))
+    tanner = CSSTannerGraph(st)
+    lx, lz = logical_operator(tanner)
+    zero_block = zeros(Mod2, size(lx))
+    n = size(lx, 2)
+    id_block = PauliString(ntuple(_ -> Pauli(0), n))
+
+    st_all = vcat([vcat(st_i, id_block) for st_i in st], [vcat(id_block, st_i) for st_i in st])
+    lx_all = vcat(hcat(lx, zero_block), hcat(zero_block, lx))
+    lz_all = vcat(hcat(lz, zero_block), hcat(zero_block, lz))
+
+    function pairwise_cnot_action(op)
+        gate = CliffordGate(ConstGate.CNOT)
+        pg = PauliGroupElement(op)
+        for i in 1:n
+            pg = gate(pg, (i, n + i))
+        end
+        return pg
+    end
+
+    function assert_logical_image(coords, x_bits, z_bits)
+        @test coords.preserves_stabilizers
+        @test coords.x_bits == x_bits
+        @test coords.z_bits == z_bits
+    end
+
+    result = logical_clifford_action(st_all, lx_all, lz_all, pairwise_cnot_action)
+
+    @test result.preserves_code
+    @test all(coords -> coords.preserves_stabilizers && !any(coords.x_bits) && !any(coords.z_bits), result.stabilizer_images)
+
+    assert_logical_image(result.x_images[1], [true, false, true, false], [false, false, false, false])
+    assert_logical_image(result.x_images[2], [false, true, false, true], [false, false, false, false])
+    assert_logical_image(result.x_images[3], [false, false, true, false], [false, false, false, false])
+    assert_logical_image(result.x_images[4], [false, false, false, true], [false, false, false, false])
+
+    assert_logical_image(result.z_images[1], [false, false, false, false], [true, false, false, false])
+    assert_logical_image(result.z_images[2], [false, false, false, false], [false, true, false, false])
+    assert_logical_image(result.z_images[3], [false, false, false, false], [true, false, true, false])
+    assert_logical_image(result.z_images[4], [false, false, false, false], [false, true, false, true])
 end
 
 @testset "code_distance" begin

--- a/test/codes/code_distance.jl
+++ b/test/codes/code_distance.jl
@@ -1,6 +1,6 @@
 using Test
 using TensorQEC
-using TensorQEC: row_echelon_form, null_space, logical_operator, same_qubit_order, verify_logical_action
+using TensorQEC: row_echelon_form, null_space, logical_operator, same_qubit_order, verify_logical_action, logical_pauli_coordinates
 using Random
 
 @testset "classical_code_distance" begin
@@ -110,6 +110,50 @@ end
     @test result2.preserves_stabilizers
     @test result2.commutes_with_lx == [true, true]
     @test result2.commutes_with_lz == [true, false]
+end
+
+@testset "logical_pauli_coordinates" begin
+    st = stabilizers(SteaneCode())
+    tanner = CSSTannerGraph(st)
+    lx, lz = logical_operator(tanner)
+    opx = PauliString(7, findall(i -> i.x, lx[1, :]) => Pauli(1))
+    opz = PauliString(7, findall(i -> i.x, lz[1, :]) => Pauli(3))
+
+    xcoords = logical_pauli_coordinates(st, lx, lz, opx)
+    @test xcoords.preserves_stabilizers
+    @test xcoords.x_bits == [true]
+    @test xcoords.z_bits == [false]
+
+    zcoords = logical_pauli_coordinates(st, lx, lz, opz)
+    @test zcoords.preserves_stabilizers
+    @test zcoords.x_bits == [false]
+    @test zcoords.z_bits == [true]
+end
+
+@testset "logical_pauli_coordinates supports multiple logical qubits" begin
+    st = stabilizers(ToricCode(3, 3))
+    tanner = CSSTannerGraph(st)
+    lx, lz = logical_operator(tanner)
+    op = PauliString(size(lx, 2), findall(i -> i.x, lx[2, :]) => Pauli(1))
+
+    coords = logical_pauli_coordinates(st, lx, lz, op)
+
+    @test coords.preserves_stabilizers
+    @test coords.x_bits == [false, true]
+    @test coords.z_bits == [false, false]
+end
+
+@testset "logical_pauli_coordinates detects broken stabilizers" begin
+    st = stabilizers(SteaneCode())
+    tanner = CSSTannerGraph(st)
+    lx, lz = logical_operator(tanner)
+    op = PauliString(7, 1 => Pauli(1))
+
+    coords = logical_pauli_coordinates(st, lx, lz, op)
+
+    @test !coords.preserves_stabilizers
+    @test coords.x_bits isa Vector{Bool}
+    @test coords.z_bits isa Vector{Bool}
 end
 
 @testset "code_distance" begin


### PR DESCRIPTION
## Summary
- add logical Pauli-coordinate and logical Clifford-action APIs for stabilizer codes
- verify double-`ToricCode(3,3)` transversal CNOT at the Pauli/matrix level
- strengthen preservation checks with stabilizer-phase and logical symplectic validation

## Test Plan
- [x] julia --project=. test/codes/code_distance.jl
- [x] julia --project=. test/runtests.jl